### PR TITLE
Descope Hosted Flow URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,19 @@ Make sure you have the following installed:
 
 ###  Run the app
 1. **Clone the Repository**: Clone this repository to your local machine.
-
-
 2. **Open the Project**: Open the project within VS Code or your IDE of choice.
-3. **Define and Host Your Flow**: Your authentication flow needs to be set up externally per the instructions [here](https://github.com/descope/descope-flutter/tree/main#running-flows). You'll use the url where you hosted the flow in the next step
-
-4. **Add Environment Variables**: Within the root directory of the project, create a `.env` file.
+3. **Add your Descope Project ID**: Within the root directory of the project, create a `.env` file. Add your Descope Project ID, which can be found in your [Descope Console](https://app.descope.com/settings/project).
 ```
 DESCOPE_PROJECT_ID=<your_descope_project_id>
+```
+4. **(Optional) Self-Host Your Flow**: Your Descope authentication flow is automatically hosted by Descope at https://auth.descope.io/<your_descope_project_id> but you can use your own domain as host per the instructions [in our docs](https://github.com/descope/descope-flutter/tree/main#running-flows). You can use your self-hosted flow url by setting this environment variable in the `.env`:
+```
 DESCOPE_FLOW_URL=<your_descope_flow_url>
 ```
-_For the `DESCOPE_PROJECT_ID`, you can look in your [Descope Console](https://app.descope.com/settings/project)._
-
-_For the `DESCOPE_FLOW_URL`, you'll need the url where you hosted your authentication flow as described above in Step #3._
 
 5. **_(Android Only)_ Add deep link and host urls:** Follow the steps [here](https://github.com/descope/descope-flutter/tree/main#android-only-setup-2-enable-app-links) to get your deep link and host urls. Then, add the former to the `.env` and latter to the `AndroidManifest.xml`:
 ```
-// lib/.env
+// .env
 
 DESCOPE_DEEP_LINK_URL=<your_descope_deep_link_url>
 ```

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Make sure you have the following installed:
 ```
 DESCOPE_PROJECT_ID=<your_descope_project_id>
 ```
-4. **(Optional) Self-Host Your Flow**: Your Descope authentication flow is automatically hosted by Descope at https://auth.descope.io/<your_descope_project_id> but you can use your own domain as host per the instructions [in our docs](https://github.com/descope/descope-flutter/tree/main#running-flows). You can use your self-hosted flow url by setting this environment variable in the `.env`:
+4. **(Optional) Self-Host Your Flow**: Your Descope authentication flow is automatically hosted by Descope at [https://auth.descope.io/<your_descope_project_id>](https://auth.descope.io/<your_descope_project_id>) but you can use your own domain as host per the instructions [in our docs](https://github.com/descope/descope-flutter/tree/main#running-flows). Then, just store your self-hosted flow url in the `.env`:
 ```
 DESCOPE_FLOW_URL=<your_descope_flow_url>
 ```
 
-5. **_(Android Only)_ Add deep link and host urls:** Follow the steps [here](https://github.com/descope/descope-flutter/tree/main#android-only-setup-2-enable-app-links) to get your deep link and host urls. Then, add the former to the `.env` and latter to the `AndroidManifest.xml`:
+5. **_(Android Only)_ Add deep link and host urls:** Follow the steps [here](https://github.com/descope/descope-flutter/tree/main#android-only-setup-2-enable-app-links) to get your deep link and host urls, which you'll store in the `.env` and `AndroidManifest.xml` respectively. You'll also need to self-host your flow and set it as described in Step 4.
 ```
 // .env
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
         applicationId "com.example.flutter_sample_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://docs.flutter.dev/deployment/android#reviewing-the-gradle-build-configuration.
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 24
         targetSdkVersion flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/lib/services/util.dart
+++ b/lib/services/util.dart
@@ -5,10 +5,11 @@ import 'package:logging/logging.dart';
 final Logger _logger = Logger('auth_service');
 
 Future<bool> startFlow() async {
-  final flowUrl = dotenv.env['DESCOPE_FLOW_URL'];
+  final String projectId = dotenv.env['DESCOPE_PROJECT_ID']!;
+
+  String? flowUrl = dotenv.env['DESCOPE_FLOW_URL'];
   if (flowUrl == null || flowUrl.isEmpty) {
-    _logger.severe('ERROR: DESCOPE_FLOW_URL is not set');
-    return false;
+    flowUrl = 'https://auth.descope.io/$projectId';
   }
   final deepLinkUrl = dotenv.env['DESCOPE_DEEP_LINK_URL'];
 


### PR DESCRIPTION
Makes Flow url env variable optional since we default to Descope hosted flow url at https://auth.descope.io.

Adjust readme and code accordingly.